### PR TITLE
Export summary and session logs per facility

### DIFF
--- a/kolibri/core/auth/constants/commands_errors.py
+++ b/kolibri/core/auth/constants/commands_errors.py
@@ -1,0 +1,30 @@
+from django.utils.translation import gettext_lazy as _
+
+# Error messages ###
+UNEXPECTED_EXCEPTION = 0
+TOO_LONG = 1
+INVALID = 2
+DUPLICATED_USERNAME = 3
+INVALID_USERNAME = 4
+REQUIRED_COLUMN = 5
+INVALID_HEADER = 6
+NO_FACILITY = 7
+FILE_READ_ERROR = 8
+FILE_WRITE_ERROR = 9
+
+MESSAGES = {
+    UNEXPECTED_EXCEPTION: _("Unexpected exception [{}]: {}"),
+    TOO_LONG: _("'{}' is too long"),
+    INVALID: _("Not a valid '{}'"),
+    DUPLICATED_USERNAME: _("Duplicated Username"),
+    INVALID_USERNAME: _(
+        "Username only can contain characters, numbers and underscores"
+    ),
+    REQUIRED_COLUMN: _("The column '{}' is required"),
+    INVALID_HEADER: _("Mix of valid and/or invalid header labels found in first row"),
+    NO_FACILITY: _(
+        "No default facility exists, please make sure to provision this device before running this command"
+    ),
+    FILE_READ_ERROR: _("Error trying to read csv file: {}"),
+    FILE_WRITE_ERROR: _("Error trying to write csv file: {}"),
+}

--- a/kolibri/core/logger/api_urls.py
+++ b/kolibri/core/logger/api_urls.py
@@ -37,7 +37,7 @@ router.urls.append(
 
 router.urls.append(
     url(
-        r"^exportedlogsinfo/(?P<facility>.*)/$",
+        r"^exportedlogsinfo/(?P<facility_id>.*)/(?P<facility>.*)/$",
         exported_logs_info,
         name="exportedlogsinfo",
     )

--- a/kolibri/core/logger/api_urls.py
+++ b/kolibri/core/logger/api_urls.py
@@ -36,7 +36,11 @@ router.urls.append(
 )
 
 router.urls.append(
-    url(r"^exportedlogsinfo/$", exported_logs_info, name="exportedlogsinfo")
+    url(
+        r"^exportedlogsinfo/(?P<facility>.*)/$",
+        exported_logs_info,
+        name="exportedlogsinfo",
+    )
 )
 
 urlpatterns = router.urls

--- a/kolibri/core/logger/api_urls.py
+++ b/kolibri/core/logger/api_urls.py
@@ -29,7 +29,7 @@ router.register(r"userprogress", TotalContentProgressViewSet, base_name="userpro
 
 router.urls.append(
     url(
-        r"^downloadcsvfile/(?P<log_type>.*)/$",
+        r"^downloadcsvfile/(?P<log_type>.*)/(?P<facility_id>.*)/$",
         download_csv_file,
         name="download_csv_file",
     )

--- a/kolibri/core/logger/csv_export.py
+++ b/kolibri/core/logger/csv_export.py
@@ -89,7 +89,7 @@ def map_object(obj):
 classes_info = {
     "session": {
         "queryset": ContentSessionLog.objects.all(),
-        "filename": "content_session_logs.csv",
+        "filename": "{}_content_session_logs.csv",
         "db_columns": (
             "user__username",
             "user__facility__name",
@@ -104,7 +104,7 @@ classes_info = {
     },
     "summary": {
         "queryset": ContentSummaryLog.objects.all(),
-        "filename": "content_summary_logs.csv",
+        "filename": "{}_content_summary_logs.csv",
         "db_columns": (
             "user__username",
             "user__facility__name",
@@ -121,7 +121,8 @@ classes_info = {
 }
 
 
-def csv_file_generator(log_type, filepath, overwrite=False):
+def csv_file_generator(facility, log_type, filepath, overwrite=False):
+
     if log_type not in ("summary", "session"):
         raise ValueError(
             "Impossible to create a csv export file for {}".format(log_type)
@@ -131,7 +132,7 @@ def csv_file_generator(log_type, filepath, overwrite=False):
 
     if not overwrite and os.path.exists(filepath):
         raise ValueError("{} already exists".format(filepath))
-    queryset = log_info["queryset"]
+    queryset = log_info["queryset"].filter(dataset_id=facility.dataset_id)
 
     # Exclude completion timestamp for the sessionlog CSV
     header_labels = tuple(

--- a/kolibri/core/logger/csv_export.py
+++ b/kolibri/core/logger/csv_export.py
@@ -25,8 +25,8 @@ from kolibri.utils import conf
 logger = logging.getLogger(__name__)
 
 CSV_EXPORT_FILENAMES = {
-    "session": "{}_content_session_logs.csv",
-    "summary": "{}_content_summary_logs.csv",
+    "session": "{}_{}_content_session_logs.csv",
+    "summary": "{}_{}_content_summary_logs.csv",
 }
 
 
@@ -163,7 +163,7 @@ def csv_file_generator(facility, log_type, filepath, overwrite=False):
             yield
 
 
-def exported_logs_info(request, facility):
+def exported_logs_info(request, facility_id, facility):
     """
     Get the last modification timestamp of the summary logs exported
 
@@ -174,7 +174,7 @@ def exported_logs_info(request, facility):
 
     for log_type in CSV_EXPORT_FILENAMES.keys():
         log_path = os.path.join(
-            logs_dir, CSV_EXPORT_FILENAMES[log_type].format(facility)
+            logs_dir, CSV_EXPORT_FILENAMES[log_type].format(facility, facility_id[:4])
         )
         if os.path.exists(log_path):
             csv_statuses[log_type] = os.path.getmtime(log_path)
@@ -189,12 +189,13 @@ def download_csv_file(request, log_type, facility_id):
         facility_name = Facility.objects.get(pk=facility_id).name
     else:
         facility_name = request.user.facility.name
+        facility_id = request.user.facility.id
 
     if log_type in CSV_EXPORT_FILENAMES.keys():
         filepath = os.path.join(
             conf.KOLIBRI_HOME,
             "log_export",
-            CSV_EXPORT_FILENAMES[log_type].format(facility_name),
+            CSV_EXPORT_FILENAMES[log_type].format(facility_name, facility_id[:4]),
         )
     else:
         filepath = None
@@ -210,7 +211,7 @@ def download_csv_file(request, log_type, facility_id):
 
     # set the content-disposition as attachment to force download
     response["Content-Disposition"] = "attachment; filename={}".format(
-        CSV_EXPORT_FILENAMES[log_type].format(facility_name)
+        CSV_EXPORT_FILENAMES[log_type].format(facility_name, facility_id[:4])
     )
 
     # set the content-length to the file size

--- a/kolibri/core/logger/csv_export.py
+++ b/kolibri/core/logger/csv_export.py
@@ -95,7 +95,7 @@ def map_object(obj):
 classes_info = {
     "session": {
         "queryset": ContentSessionLog.objects.all(),
-        "filename": "{}_content_session_logs.csv",
+        "filename": CSV_EXPORT_FILENAMES["session"],
         "db_columns": (
             "user__username",
             "user__facility__name",
@@ -110,7 +110,7 @@ classes_info = {
     },
     "summary": {
         "queryset": ContentSummaryLog.objects.all(),
-        "filename": "{}_content_summary_logs.csv",
+        "filename": CSV_EXPORT_FILENAMES["summary"],
         "db_columns": (
             "user__username",
             "user__facility__name",
@@ -163,21 +163,19 @@ def csv_file_generator(facility, log_type, filepath, overwrite=False):
             yield
 
 
-def exported_logs_info(request):
+def exported_logs_info(request, facility):
     """
     Get the last modification timestamp of the summary logs exported
 
     :returns: An object with the files informatin
     """
-
     logs_dir = os.path.join(conf.KOLIBRI_HOME, "log_export")
     csv_statuses = {}
-    csv_export_filenames = {
-        "session": "content_session_logs.csv",
-        "summary": "content_summary_logs.csv",
-    }
-    for log_type in csv_export_filenames.keys():
-        log_path = os.path.join(logs_dir, csv_export_filenames[log_type])
+
+    for log_type in CSV_EXPORT_FILENAMES.keys():
+        log_path = os.path.join(
+            logs_dir, CSV_EXPORT_FILENAMES[log_type].format(facility)
+        )
         if os.path.exists(log_path):
             csv_statuses[log_type] = os.path.getmtime(log_path)
         else:

--- a/kolibri/core/logger/management/commands/exportlogs.py
+++ b/kolibri/core/logger/management/commands/exportlogs.py
@@ -87,7 +87,7 @@ class Command(AsyncCommand):
             log_info = classes_info[log_type]
 
             if options["output_file"] is None:
-                filename = log_info["filename"].format(facility.name)
+                filename = log_info["filename"].format(facility.name, facility.id[:4])
             else:
                 filename = options["output_file"]
 

--- a/kolibri/core/tasks/api.py
+++ b/kolibri/core/tasks/api.py
@@ -580,13 +580,16 @@ class TasksViewSet(viewsets.ViewSet):
 
         """
         csv_export_filenames = {
-            "session": "content_session_logs.csv",
-            "summary": "content_summary_logs.csv",
+            "session": "{}_content_session_logs.csv",
+            "summary": "{}_content_summary_logs.csv",
         }
+        facility = request.user.facility
         log_type = request.data.get("logtype", "summary")
         if log_type in csv_export_filenames.keys():
             logs_dir = os.path.join(conf.KOLIBRI_HOME, "log_export")
-            filepath = os.path.join(logs_dir, csv_export_filenames[log_type])
+            filepath = os.path.join(
+                logs_dir, csv_export_filenames[log_type].format(facility.name)
+            )
         else:
             raise Http404(
                 "Impossible to create a csv export file for {}".format(log_type)
@@ -605,6 +608,7 @@ class TasksViewSet(viewsets.ViewSet):
             "exportlogs",
             log_type=log_type,
             output_file=filepath,
+            facility=facility.id,
             overwrite="true",
             extra_metadata=job_metadata,
             track_progress=True,

--- a/kolibri/core/tasks/api.py
+++ b/kolibri/core/tasks/api.py
@@ -604,7 +604,11 @@ class TasksViewSet(viewsets.ViewSet):
             "EXPORTSUMMARYLOGCSV" if log_type == "summary" else "EXPORTSESSIONLOGCSV"
         )
 
-        job_metadata = {"type": job_type, "started_by": request.user.pk}
+        job_metadata = {
+            "type": job_type,
+            "started_by": request.user.pk,
+            "facility": facility.id,
+        }
 
         job_id = priority_queue.enqueue(
             call_command,

--- a/kolibri/core/tasks/api.py
+++ b/kolibri/core/tasks/api.py
@@ -591,7 +591,8 @@ class TasksViewSet(viewsets.ViewSet):
         if log_type in CSV_EXPORT_FILENAMES.keys():
             logs_dir = os.path.join(conf.KOLIBRI_HOME, "log_export")
             filepath = os.path.join(
-                logs_dir, CSV_EXPORT_FILENAMES[log_type].format(facility.name)
+                logs_dir,
+                CSV_EXPORT_FILENAMES[log_type].format(facility.name, facility_id[:4]),
             )
         else:
             raise Http404(

--- a/kolibri/plugins/facility/assets/src/modules/manageCSV/actions.js
+++ b/kolibri/plugins/facility/assets/src/modules/manageCSV/actions.js
@@ -40,7 +40,7 @@ function startSessionCSVExport(store) {
 
 function getExportedLogsInfo(store) {
   return client({
-    path: urls['kolibri:core:exportedlogsinfo'](),
+    path: urls['kolibri:core:exportedlogsinfo'](store.rootGetters.currentFacilityName),
   }).then(response => {
     const data = response.entity;
     let sessionTimeStamp = null;

--- a/kolibri/plugins/facility/assets/src/modules/manageCSV/actions.js
+++ b/kolibri/plugins/facility/assets/src/modules/manageCSV/actions.js
@@ -40,7 +40,10 @@ function startSessionCSVExport(store) {
 
 function getExportedLogsInfo(store) {
   return client({
-    path: urls['kolibri:core:exportedlogsinfo'](store.rootGetters.currentFacilityName),
+    path: urls['kolibri:core:exportedlogsinfo'](
+      store.rootGetters.activeFacilityId,
+      store.rootGetters.currentFacilityName
+    ),
   }).then(response => {
     const data = response.entity;
     let sessionTimeStamp = null;

--- a/kolibri/plugins/facility/assets/src/modules/manageCSV/actions.js
+++ b/kolibri/plugins/facility/assets/src/modules/manageCSV/actions.js
@@ -57,16 +57,19 @@ function getExportedLogsInfo(store) {
 }
 
 function checkTaskStatus(store, newTasks, taskType, taskId, commitStart, commitFinish) {
+  const myNewTasks = newTasks.filter(task => {
+    return task.facility === store.rootGetters.activeFacilityId;
+  });
   // if task job has already been fetched, just continually check if its completed
   if (taskId) {
-    const task = newTasks.find(task => task.id === taskId);
+    const task = myNewTasks.find(task => task.id === taskId);
 
     if (task && task.status === TaskStatuses.COMPLETED) {
       store.commit(commitFinish, new Date());
       TaskResource.deleteFinishedTask(taskId);
     }
   } else {
-    const running = newTasks.filter(task => {
+    const running = myNewTasks.filter(task => {
       return (
         task.type === taskType &&
         task.status !== TaskStatuses.COMPLETED &&

--- a/kolibri/plugins/facility/assets/src/modules/manageCSV/actions.js
+++ b/kolibri/plugins/facility/assets/src/modules/manageCSV/actions.js
@@ -9,6 +9,7 @@ const logging = logger.getLogger(__filename);
 function startCSVExport(store, logtype, creating, commitStart) {
   const params = {
     logtype: logtype,
+    facility: store.rootGetters.activeFacilityId,
   };
   if (!creating) {
     let promise = TaskResource.startexportlogcsv(params);

--- a/kolibri/plugins/facility/assets/src/views/DataPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/DataPage/index.vue
@@ -116,6 +116,7 @@
         'availableSessionCSVLog',
         'availableSummaryCSVLog',
       ]),
+      ...mapGetters(['activeFacilityId']),
       ...mapState('manageCSV', ['sessionDateCreated', 'summaryDateCreated']),
       cannotDownload() {
         return isEmbeddedWebView;
@@ -170,10 +171,16 @@
         }
       },
       downloadSessionLog() {
-        window.open(urls['kolibri:core:download_csv_file']('session'), '_blank');
+        window.open(
+          urls['kolibri:core:download_csv_file']('session', this.activeFacilityId),
+          '_blank'
+        );
       },
       downloadSummaryLog() {
-        window.open(urls['kolibri:core:download_csv_file']('summary'), '_blank');
+        window.open(
+          urls['kolibri:core:download_csv_file']('summary', this.activeFacilityId),
+          '_blank'
+        );
       },
     },
     $trs: {


### PR DESCRIPTION
### Summary
Exporting logs in csv format will take into account the active facility, allowing exporting concurrently from different facilities.
In the backend, 
exportlogs command now accepts a --facility id argument, if none is provided, it will use the default facility.

In the frontend, in a Multi-Facility-Device, different users from different facilties with the right permissions can export the session or summary logs concurrently.



### Reviewer guidance
Does kolibri manage exportcsv work as intended?
Using different browsers or an incongito window to be impersonated as different users from different facilities (or a super-admin in different facilities) can download the logs at the same time?
Also, if being in the same facility, is it blocked until the log file creation is finished?

![facilities_logs](https://user-images.githubusercontent.com/1008178/79134144-8278f200-7dad-11ea-9d5f-bd00a4afd019.gif)

### References
Relates #6769



### Contributor Checklist

- [x] Contributor has fully tested the PR manually
- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

### Reviewer Checklist

- [ ] Automated test coverage is satisfactory
- [x] Reviewer has fully tested the PR manually
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependencies files were updated (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Link to diff of internal dependency change is included
- [ ] CHANGELOG.rst is updated for high-level changes
- [ ] Contributor is in AUTHORS.rst
