### PR TITLE
0.14.0-beta7 bug fixes - review

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/ExamPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/ExamPage/index.vue
@@ -44,7 +44,7 @@
           </KPageContainer>
 
           <BottomAppBar :dir="bottomBarLayoutDirection" :maxWidth="null">
-            <KButtonGroup style="margin-top: 8px;">
+            <KButtonGroup>
               <UiIconButton
                 v-if="windowBreakpoint === 0"
                 :aria-label="$tr('nextQuestion')"


### PR DESCRIPTION
### Summary

Remove top margin from group buttons in bottom bar on exam page.

![ExamPage-bottom bar](https://user-images.githubusercontent.com/13509191/86489834-cef91b80-bd65-11ea-8e68-0832e720d541.png)

### References

#7238
